### PR TITLE
[FIX glimmer] Update the title & content in the afterRender

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -7,11 +7,15 @@ export default Ember.Component.extend({
     attributeBindings: ['title'],
 
     updateTitle: Ember.observer('title', function() {
+      Ember.run.schedule('afterRender', this, function() {
         this.$().tooltipster('content', this.get('title'));
+      });
     }),
 
     updateContent: Ember.observer('content', function(){
-      this.$().tooltipster('content', this.get('content'));
+      Ember.run.schedule('afterRender', this, function() {
+        this.$().tooltipster('content', this.get('content'));
+      });
     }),
 
     /**


### PR DESCRIPTION
Otherwise, the element can still not be in the dom an fail. This
should fix the addon for glimmer.