### PR TITLE
Using Ember.on instead of .on from prototype so can work with plugins

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
         'updateAnimation'
     ],
 
-    _initializeTooltipster: function() {
+    _initializeTooltipster: Ember.on('didInsertElement', function() {
         var _this = this;
         var options = {};
 
@@ -50,9 +50,9 @@ export default Ember.Component.extend({
 
         this.$().tooltipster(options);
 
-    }.on('didInsertElement'),
+    }),
 
-    _destroyTooltipster: function() {
+    _destroyTooltipster: Ember.on('willDestroyElement', function() {
         this.$().tooltipster('destroy');
-    }.on('willDestroyElement'),
+    }),
 });


### PR DESCRIPTION
This just changes from .on to Ember.on.