### PR TITLE
Enable pluginOptions field to whitelist options created by plugins

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -58,11 +58,22 @@ export default Ember.Component.extend({
   ],
 
   _initializeTooltipster: on('didInsertElement', function() {
-    let options = this._getStandardOptions();
+    let options = this._getOptions();
     let componentElement = this.$();
     componentElement.tooltipster(options);
     this.set('tooltipsterInstance', componentElement.tooltipster('instance'));
   }),
+
+  _getOptions() {
+    let options = this._getStandardOptions();
+
+    let pluginOptions = this._getPluginOptions();
+    for (var option in pluginOptions) {
+      options[option] = pluginOptions[option];
+    }
+
+    return options;
+  },
 
   _getStandardOptions() {
     let options = {};
@@ -81,6 +92,17 @@ export default Ember.Component.extend({
     ['functionInit', 'functionBefore', 'functionReady', 'functionAfter', 'functionFormat', 'functionPosition'].forEach(fn => {
       options[fn] = $.proxy(this[fn], this);
     });
+    return options;
+  },
+
+  _getPluginOptions() {
+    let options = {};
+    let pluginOptionKeys = this.get('pluginOptions');
+    if (!isEmpty(pluginOptionKeys)) {
+      pluginOptionKeys.forEach((pluginOption) => {
+        options[pluginOption] = this.get(pluginOption);
+      });
+    }
     return options;
   },
 


### PR DESCRIPTION
## The Problem

[Version 0.4.3](https://github.com/altrim/ember-cli-tooltipster/releases/tag/v0.4.3) whitelisted the `plugins` option to allow for tooltipster plugins to be used, as raised in #21. While this did allow plugins to be used, it limited their functionality by preventing the new options the plugins provide to be used.

*Example*: [tooltipster-follower](https://github.com/louisameline/tooltipster-follower) lets the tooltip follow the cursor as well as provide the `offset` and `anchor` options for increased customization. However, because `offset` and `anchor` are not explicitly whitelisted as well, this library does not recognize the options.

## The Solution

I thought of a few different solutions to this issue. The first would be to ask for `offset` and `anchor` to be added to the whitelist as well, but this does not solve the general problem of plugin options for _any_ plugin.

Another possibility was to dynamically obtain the keys for all of the component's defined properties and add them as options to the tooltipster - this way, options would be easily added without manual whitelisting. However, the tooltipster is still an ember component and it may have other properties that are not options.

The solution I arrived at is adding another property to the tooltipster component, `pluginOptions`, which is an array of strings that whitelists which additional options should be inserted into the tooltipster. This way, users can use any plugins and any additional options provided by those plugins.

## This PR

This PR changes the way that the component obtains its `options`. Instead of directly calling `this._getStandardOptions`, it delegates that action to a more generic `this._getOptions`, which obtains the options whitelisted in `tooltipsterOptions` and merges the options specified in `pluginOptions` to that object.

In order to be used correctly, one's component would have to look something like this (using `tooltipster-follower` as the example):

```
import TooltipsterComponent from 'ember-cli-tooltipster/components/tool-tipster';

export default TooltipsterComponent.extend({
  content: 'My content',
  plugins: ['follower'],
  pluginOptions: ['offset', 'anchor'],
  offset: [0,0],
  anchor: 'bottom-left'
});
```
---

Here's a GIF of the `tooltipster-follower` in action, using the `offset` and `anchor` options, whitelisted through `pluginOptions`.

![xveteb1zfe](https://cloud.githubusercontent.com/assets/7132760/17227811/2129f7e8-54de-11e6-8c4e-f9ecaf9613fc.gif)
