### PR TITLE
Ensure 'tooltipsterInstance' present before assigning content

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -112,7 +112,9 @@ export default Ember.Component.extend({
       if (content instanceof SafeString) {
         content = content.toString();
       }
-      this.get('tooltipsterInstance').content(content);
+      if (this.get('tooltipsterInstance') !== null) {
+        this.get('tooltipsterInstance').content(content);
+      }
     });
   }),
 


### PR DESCRIPTION
## What's Up

As documented in #23, a timing issue may arise where `tooltipsterInstance` is set to `null` by `_destroyElement` yet the observer `_onContentDidChange` receives an update before the tooltipster is actually destroyed.

## What This Does

This quick fix ensures that the `tooltipsterInstance` exists before assigning it new content.