### PR TITLE
Option to disable default/built-in styles and Ember 2.8 SafeString DEPRECATION

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -6,8 +6,8 @@ const {
   on,
   isEmpty,
   $,
-  Handlebars: {
-    SafeString
+  String: {
+    htmlSafe
   }
 } = Ember;
 
@@ -84,8 +84,8 @@ export default Ember.Component.extend({
       }
     });
     options.trigger = this.get('triggerEvent');
-    // Handle SafeString
-    if (content instanceof SafeString) {
+    // Handle htmlSafe
+    if (content instanceof htmlSafe) {
       options.content = content.toString();
     }
 
@@ -109,7 +109,7 @@ export default Ember.Component.extend({
   _onContentDidChange: observer('content', 'title', function() {
     run.scheduleOnce('afterRender', this, () => {
       let content = this.get('content') || this.get('title');
-      if (content instanceof SafeString) {
+      if (content instanceof htmlSafe) {
         content = content.toString();
       }
       if (this.get('tooltipsterInstance') !== null) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var util = require('util');
 var extend = util._extend;
 
 var defaultOptions = {
+  importTooltipsterDefaultStyles: true,
   importTooltipsterBorderless: false,
   importTooltipsterLight: false,
   importTooltipsterNoir: false,
@@ -21,9 +22,10 @@ module.exports = {
 
     var options = extend(defaultOptions, app.options['ember-cli-tooltipster']);
     var themesPath = path.join(app.bowerDirectory, 'tooltipster/dist/css/plugins/tooltipster/sideTip/themes/');
-
-    app.import(app.bowerDirectory + '/tooltipster/dist/css/tooltipster.bundle.min.css');
-
+    
+    if (options.importTooltipsterDefaultStyles) {
+      app.import(app.bowerDirectory + '/tooltipster/dist/css/tooltipster.bundle.min.css');
+    }
     if (options.importTooltipsterBorderless) {
       app.import(path.join(themesPath, 'tooltipster-sideTip-borderless.min.css'));
     }


### PR DESCRIPTION
I think the community would also like to be able to do completely do away the bundled base css.