### PR TITLE
Use polyfill isHTMLSafe to handle safe string and maintain backwards compatibility

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -1,14 +1,12 @@
 import Ember from 'ember';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const {
   run,
   observer,
   on,
   isEmpty,
-  $,
-  Handlebars: {
-    SafeString
-  }
+  $
 } = Ember;
 
 export default Ember.Component.extend({
@@ -84,8 +82,8 @@ export default Ember.Component.extend({
       }
     });
     options.trigger = this.get('triggerEvent');
-    // Handle SafeString
-    if (content instanceof SafeString) {
+    // Handle safe string using ishtmlsafe-polyfill
+    if (isHTMLSafe(content)) {
       options.content = content.toString();
     }
 
@@ -109,7 +107,7 @@ export default Ember.Component.extend({
   _onContentDidChange: observer('content', 'title', function() {
     run.scheduleOnce('afterRender', this, () => {
       let content = this.get('content') || this.get('title');
-      if (content instanceof SafeString) {
+      if (isHTMLSafe(content)) {
         content = content.toString();
       }
       if (this.get('tooltipsterInstance') !== null) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-paper": "0.2.14",
     "ember-resolver": "^2.0.3",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "loader.js": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
This PR is to use the polyfill isHTMLSafe to check if the string is safe to parse, since the check `String.isHTMLSafe` in Ember version 2.8 is not compatible to version 2.7 or lower.

It is also good to move out of the `Handlebars.SafeString` as it is deprecated in Ember version 2.8