### PR TITLE
make sure we can use this addon with Ember versions below 2.5.x 

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -11,6 +11,7 @@ const {
 } = Ember;
 
 const assign = Object.assign || Ember.assign;
+const merge = Ember.merge;
 
 export default Ember.Component.extend({
   tooltipsterInstance: null,
@@ -97,8 +98,12 @@ export default Ember.Component.extend({
     ['functionInit', 'functionBefore', 'functionReady', 'functionAfter', 'functionFormat', 'functionPosition'].forEach(fn => {
       options[fn] = $.proxy(this[fn], this);
     });
-
-    return assign({}, addonConfig, options);
+    if (!isEmpty(assign)) {
+      return assign({}, addonConfig, options);
+    } else {
+      const localAddonConfing = merge({}, addonConfig);
+      return merge(localAddonConfing, options);
+    }
   },
 
   _getPluginOptions() {

--- a/tests/integration/components/tool-tipster-test.js
+++ b/tests/integration/components/tool-tipster-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
 
 moduleForComponent('tool-tipster', 'Integration | Component | tool tipster', {
   integration: true
@@ -21,4 +22,21 @@ test('it renders', function(assert) {
   `);
 
   assert.equal(this.$().text().trim(), 'template block text');
+});
+
+
+test('would work without Object.assign or Ember.assign present', function(assert) {
+  const originalAssignRef = Object.assign;
+  const emberAssignRef = Ember.assign;
+  Object.assign = undefined;
+  Ember.assign = undefined;
+  this.render(hbs`
+    {{#tool-tipster}}
+      template block text
+    {{/tool-tipster}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+  Object.assign = originalAssignRef;
+  Ember.assign = emberAssignRef;
 });


### PR DESCRIPTION
`Ember.assign` was first introduced in 2.5.x. If we try to use this add on with 2.4.x versions it might break if clients browser don't implement `Object.assign`. This PR makes sure we would try to use Ember.merge as the last resort when neither of the above are present.