### PR TITLE
Allow ember addons to use ember-cli-tooltipster as dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,14 @@ var defaultOptions = {
 module.exports = {
   name: 'ember-cli-tooltipster',
 
-  included: function(app) {
-    this._super.included(app);
-
+  included: function(parent) {
+    this._super.included(parent);
+    var app;
+    if (parent.app) {
+      app = parent.app;
+    } else {
+      app = parent;
+    }
     var options = extend(defaultOptions, app.options['ember-cli-tooltipster']);
     var themesPath = path.join(app.bowerDirectory, 'tooltipster/dist/css/plugins/tooltipster/sideTip/themes/');
 


### PR DESCRIPTION
`included` hook in ember-cli `Addon` class accepts `parent` argument, not `app`. For that reason when the `ember-cli-tooltipster` 's parent is other Ember addon, not Ember application this `parent` prop wouldn't have options property on it as this property should exist on ember-cli `EmberApp` class instance which is then referenced as `parent.app`. If the `parent` has `app` prop present we should assume that `ember-cli-tooltipster` is coming as a dependency of Ember addon and look for `options` object on the app itself instead.