### PR TITLE
Upgrading ember-string-ishtmlsafe-polyfill

### DIFF
--- a/addon/components/tool-tipster.js
+++ b/addon/components/tool-tipster.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const {
   $,
@@ -10,6 +9,8 @@ const {
   on,
   run
 } = Ember;
+
+const { isHTMLSafe } = Ember.String;
 
 const assign = Object.assign || Ember.assign;
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "popover"
   ],
   "dependencies": {
-    "ember-string-ishtmlsafe-polyfill": "^1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0",
     "ember-cli-babel": "^5.2.1"
   },
   "ember-addon": {


### PR DESCRIPTION
👋 -- We're updating [ember-string-ishtmlsafe-polyfill](https://github.com/workmanw/ember-string-ishtmlsafe-polyfill) to be a "native polyfill". Following the pattern provided by [ember-assign-polyfill](https://github.com/shipshapecode/ember-assign-polyfill) and [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill).

Note: This is part of an effort to get all users of the polyfill updated.. workmanw/ember-string-ishtmlsafe-polyfill#5
