### PR TITLE
updating ember-string-ishtmlsafe-polyfill to 2.0.2 to avoid deprecation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "broccoli-merge-trees": "3.0.0",
     "broccoli-stew": "1.5.0",
     "ember-cli-babel": "6.12.0",
-    "ember-string-ishtmlsafe-polyfill": "2.0.0",
+    "ember-string-ishtmlsafe-polyfill": "2.0.2",
     "tooltipster": "4.2.6"
   },
   "ember-addon": {


### PR DESCRIPTION
```
DEPRECATION: An addon is trying to access project.nodeModulesPath. This is not a reliable way to discover npm modules. Instead, consider doing: require("resolve").sync(something, { basedir: project.root }). Accessed from:   new NPMDependencyVersionChecker ($REPOHOME/node_modules/ember-string-ishtmlsafe-polyfill/node_modules/ember-cli-version-checker/src/npm-dependency-version-checker.js:11:33)
```